### PR TITLE
Export defines PUBLIC so that headers work properly

### DIFF
--- a/src/dft/CMakeLists.txt
+++ b/src/dft/CMakeLists.txt
@@ -351,6 +351,10 @@ set_target_properties(${TARGET_LIBDFT} PROPERTIES
 
 # Install
 
+target_compile_definitions(${TARGET_LIBDFT}
+    PUBLIC ${COMMON_TARGET_DEFINITIONS}
+)
+
 install(FILES ${PROJECT_SOURCE_DIR}/include/sleefdft.h DESTINATION include)
 install(TARGETS ${TARGET_LIBDFT}
         EXPORT "${targets_export_name}"

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -174,15 +174,15 @@ set_target_properties(${TARGET_LIBSLEEF} PROPERTIES
   ${COMMON_TARGET_PROPERTIES}
 )
 
-target_compile_definitions(${TARGET_LIBSLEEF} 
-  PRIVATE DORENAME=1 ${COMMON_TARGET_DEFINITIONS}
+target_compile_definitions(${TARGET_LIBSLEEF}
+  PRIVATE DORENAME=1 PUBLIC ${COMMON_TARGET_DEFINITIONS}
 )
 
 if(COMPILER_SUPPORTS_FLOAT128)
   # TODO: Not supported for LLVM bitcode gen as it has a specific compilation flags
   target_sources(${TARGET_LIBSLEEF} PRIVATE sleefqp.c)
   target_compile_definitions(${TARGET_LIBSLEEF}
-    PRIVATE ENABLEFLOAT128=1 ${COMMON_TARGET_DEFINITIONS})
+    PUBLIC ENABLEFLOAT128=1)
 endif()
 
 if(COMPILER_SUPPORTS_BUILTIN_MATH)


### PR DESCRIPTION
Copy defines over correctly so that things like static work on Windows when the defines are checked in the header